### PR TITLE
Adding Opcity to Industry Adoption section

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,14 +279,16 @@
                         <a href="http://www.boomtownroi.com">BoomTown</a>,
                         <a href="https://smartzip.com/products/smart-targeting">SmartTargeting</a> (<a href="http://www.smartzip.com">SmartZip Analytics, Inc.</a>),
                         <a href="http://www.dakno.com">Dakno Marketing</a>,
-                        <a href="https://www.followupboss.com/">Follow Up Boss</a>, and
-                        <a href="https://www.guerillarealty.com/">GuerillaRealty.com</a> can consume emails with lead metadata.</li>
+                        <a href="https://www.followupboss.com/">Follow Up Boss</a>,
+                        <a href="https://www.guerillarealty.com/">GuerillaRealty.com</a>, and
+                        <a href="https://www.opcity.com/">Opcity</a> can consume emails with lead metadata.</li>
                     <li>Most outbound <a href="http://www.realtor.com">Realtor.com</a> (Move, Inc.) lead emails include lead metadata.</li>
                     <li>
                         All <a href="http://www.tigerlead.com">TigerLead</a>,
                         <a href="https://smartzip.com/products/smart-targeting">SmartTargeting</a>,
-                        <a href="https://www.guerillarealty.com/">GuerillaRealty.com</a>, and
-                        <a href="http://www.dakno.com">Dakno Marketing</a> lead emails include lead metadata.
+                        <a href="https://www.guerillarealty.com/">GuerillaRealty.com</a>,
+                        <a href="http://www.dakno.com">Dakno Marketing</a>, and
+                        <a href="http://www.opcity.com">Opcity</a> lead emails include lead metadata.
                     </li>
                     <li>Some outbound <a href="https://www.apartmentlist.com">Apartment List</a> lead emails include lead metadata.</li>
                 </ul>


### PR DESCRIPTION
Opcity now supports the lead meta data spec for all inbound leads and outbound referrals/leads. Details on what is supported can be found here: https://opcity.zendesk.com/hc/en-us/articles/360003857294-Sending-Opcity-Referrals-to-your-CRM