### PR TITLE
Use third-person singular gender-neutral pronoun

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,8 +74,7 @@
                 the lead information, everybody loses. The real estate
                 portal appears to be handing out bad leads, the real
                 estate agent loses a potential client, and the
-                potential homebuyer does not get the service he or she
-                needs.
+                potential homebuyer does not get the service they need.
             </p>
             <p>
                 The Real Estate Lead Metadata Specification describes


### PR DESCRIPTION
The specification does a great job avoiding unnecessary gendered language, which can help increase adoption by people who identify as or support those of a non-binary gender. This patch resolves the one remaining usage of gendered pronouns.