### PR TITLE
Add zBuyer.com to list of consumable sources

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,8 +286,9 @@
                         All <a href="https://smartzip.com/products/smart-targeting">SmartTargeting</a>,
                         <a href="https://www.guerillarealty.com/">GuerillaRealty.com</a>,
                         <a href="http://www.realtyninja.com">RealtyNinja</a>,
-                        <a href="http://www.dakno.com">Dakno Marketing</a>, and
-                        <a href="http://www.opcity.com">Opcity</a> lead emails include lead metadata.
+                        <a href="http://www.dakno.com">Dakno Marketing</a>,
+                        <a href="http://www.opcity.com">Opcity</a>, and 
+                        <a href="http://www.zbuyer.com">zBuyer</a> lead emails include lead metadata.
                     </li>
                     <li>Some outbound <a href="https://www.apartmentlist.com">Apartment List</a> lead emails include lead metadata.</li>
                 </ul>


### PR DESCRIPTION
All zBuyer.com lead emails follow the leadmetadata.org specs as of 8-20-2018.