### PR TITLE
Adding Wise Agent to Industry Adoption section

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,7 +281,8 @@
                         <a href="https://www.followupboss.com/">Follow Up Boss</a>,
                         <a href="https://www.guerillarealty.com/">GuerillaRealty.com</a>,
                         <a href="https://www.opcity.com/">Opcity</a>, and 
-                        <a href="https://www.realoffice360.com">RealOffice360</a> can consume emails with lead metadata.</li>
+                        <a href="https://www.realoffice360.com">RealOffice360</a>, and
+                        <a href="https://www.wiseagent.com/">Wise Agent</a> can consume emails with lead metadata.</li>
                     <li>Most outbound <a href="http://www.realtor.com">Realtor.com</a> (Move, Inc.) lead emails include lead metadata.</li>
                     <li>
                         All <a href="https://smartzip.com/products/smart-targeting">SmartTargeting</a>,


### PR DESCRIPTION
Wise Agent now supports the lead meta data spec for all inbound leads. 